### PR TITLE
add default queue size

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var express = require('express');
 var bodyParser = require('body-parser');
 var PropertiesReader = require('properties-reader');
-var properties = PropertiesReader('settings.cfg');
+var properties = PropertiesReader(__dirname + '/settings.cfg');
 
 var queueSize = properties.get('main.queue.size');
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "method-override":"*",
     "body-parser": "^1.17.1",
     "express": "^4.15.2",
-    "stackjs": "^0.1.0"
+    "stackjs": "^0.1.0",
+    "properties-reader":"*"
   }
 }

--- a/settings.cfg
+++ b/settings.cfg
@@ -1,0 +1,2 @@
+[main]
+queue.size=10


### PR DESCRIPTION
1. Maintain max queue size. Default to 10
2. Dequeue the oldest item when pushing the new one if the queue is full
3. Return {} when the queue is empty